### PR TITLE
Fix crashing due to newer gradle

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -25,3 +25,4 @@ android.useAndroidX=true
 android.enableJetifier=true
 # Version of flipper SDK to use with React Native
 FLIPPER_VERSION=0.33.1
+android.enableDexingArtifactTransform.desugaring=false


### PR DESCRIPTION
There might still be crashes due to Flipper but that should at least kill the webrtc related crash.